### PR TITLE
Correctly use flag for given arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Links :
 
 ## Run
 
-You can use ``cargo run <file to run>`` to run the project.
+You can use ``cargo run -- <file to run>`` to run the project.
 
 WARNING : please use this directory as the working directory, not 'src'.

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,23 +13,24 @@ use pre_run::{get_instructions, get_path};
 use skribi_language_source::{clear, read};
 use std::env;
 
+const FLAG_CHAR: &str = "--";
+
 /**
  * Launch the interpreter
  */
 fn main() {
     // parameters
-    let flag_char = "/"; // if it was "-", it would sometimes interfere with cargo's flags
     let extension: Vec<String> = vec!["skrb".to_string(), "skribi".to_string()];
 
     // generic parameters
-    let args: Vec<_> = env::args().collect(); // get the command line arguments
+    let args = env::args().collect::<Vec<_>>(); // get the command line arguments
 
     // clear the shell for the user
-    if !args.contains(&String::from(flag_char.to_string() + "interpret-debug")) {
+    if !args.contains(&format!("{FLAG_CHAR}interpret-debug")) {
         clear();
     }
 
-    let path = get_path(args.clone(), flag_char);
+    let path = get_path(args.clone());
 
     // Check if the file has the right extension
     if !extension.contains(&String::from(path.split('.').last().unwrap())) {

--- a/src/pre_run.rs
+++ b/src/pre_run.rs
@@ -1,15 +1,17 @@
 use skribi_language_source::error;
 use std::io;
 
+use crate::FLAG_CHAR;
+
 /**
  * This function is used to get the path of the file to run
  *
  * The path can either be passed as an argument or entered in the terminal
  */
-pub fn get_path(args: Vec<String>, flag_char: &str) -> String {
+pub fn get_path(args: Vec<String>) -> String {
     let mut path = String::new();
     // Get the path of the file to run
-    if args.len() > 1 && !args[1].starts_with(flag_char) {
+    if args.len() > 1 && !args[1].starts_with(FLAG_CHAR) {
         path = args[1].clone();
     } else {
         println!("Enter a file to run");


### PR DESCRIPTION
Uses `--` instead of `/` for arguments given to the program.
Cargo has a special way of handling flags given to the program: you have to write `--` after the cargo arguments.
Example:
```
cargo run -- --interpreted-debug
```